### PR TITLE
feat: allow specifying COSE header when signing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@
 //! assert!(SystemTime::now().duration_since(UNIX_EPOCH).unwrap() < exp2);
 //! ```
 //!
-//! # JWT headers
+//! # JWT/CWT headers
 //!
 //! When signing with `sign_jwt_pem`/`sign_jwk_der`, only the `alg` header is set in the resulting
 //! JWT based on the the specified algorithm. If other headers need to be specified, then
@@ -246,9 +246,13 @@
 //! `jwt::Header` instead of an algorithm. A new header can be created from an algorithm using
 //! `new_jwt_header`.
 //!
+//! The same goes when signing as COSE_Sign1Message. Only `alg` header is set by default, however,
+//! `_with_header` signing methods can be used to specify a custom `cose::headers::CoseHeader`,
+//! which can be reating from an algorithm using `new_cwt_header`.
+//!
 //! ```
 //! use std::collections::BTreeMap;
-//! use ear::{Ear, VerifierID, Algorithm, Appraisal, Extensions, new_jwt_header};
+//! use ear::{Ear, VerifierID, Algorithm, Appraisal, Extensions, new_jwt_header, new_cose_header};
 //!
 //! const SIGNING_KEY: &str = "-----BEGIN PRIVATE KEY-----
 //! MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgPp4XZRnRHSMhGg0t
@@ -271,11 +275,20 @@
 //!         extensions: Extensions::new(),
 //!     };
 //!
-//!     let mut header = new_jwt_header(&Algorithm::ES256).unwrap();
-//!     // set additional header(s)
-//!     header.kid = Some("key-ident".to_string());
+//!     // JWT
 //!
-//!     let signed = token.sign_jwt_pem_with_header(&header, SIGNING_KEY.as_bytes()).unwrap();
+//!     let mut jwt_header = new_jwt_header(&Algorithm::ES256).unwrap();
+//!     // set additional header(s)
+//!     jwt_header.kid = Some("key-ident".to_string());
+//!
+//!     let signed_jwt = token.sign_jwt_pem_with_header(&jwt_header, SIGNING_KEY.as_bytes()).unwrap();
+//!     // CWT
+//!
+//!     let mut cwt_header = new_cose_header(&Algorithm::ES256).unwrap();
+//!     // set additional header(s)
+//!     cwt_header.kid("key-ident".as_bytes().to_vec(), true, false);
+//!
+//!     let signed_cwt = token.sign_cose_pem_with_header(cwt_header, SIGNING_KEY.as_bytes()).unwrap();
 //! }
 //! ```
 //!
@@ -303,6 +316,7 @@ mod trust;
 pub use self::algorithm::Algorithm;
 pub use self::appraisal::Appraisal;
 pub use self::base64::Bytes;
+pub use self::ear::new_cose_header;
 pub use self::ear::new_jwt_header;
 pub use self::ear::Ear;
 pub use self::error::Error;


### PR DESCRIPTION
- Add alternative versions of signing methods that take a cose::headers::CoseHeader instead of an algorithm.
- Add new_cose_header helper function that creates a new jwt::Header from an Algorithm.