### PR TITLE
fix: replace ExtensionValue with RawValue

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -108,7 +108,7 @@ allow = [
     "Apache-2.0",
     "ISC",
     "OpenSSL",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
     #"Apache-2.0 WITH LLVM-exception",
     # Considered Copyleft, but permitted in this project
     "MPL-2.0",

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -79,7 +79,7 @@ impl<'de> Deserialize<'de> for Bytes {
 
 struct BytesVisitor;
 
-impl<'de> Visitor<'de> for BytesVisitor {
+impl Visitor<'_> for BytesVisitor {
     type Value = Bytes;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/ear.rs
+++ b/src/ear.rs
@@ -609,6 +609,7 @@ fn alg_to_cose(alg: &Algorithm) -> Result<i32, Error> {
 mod test {
     use super::*;
     use crate::extension::*;
+    use crate::raw::{RawValue, RawValueKind};
     use ciborium::{de::from_reader, ser::into_writer};
 
     const EAR_STRING: &str = r#"
@@ -805,20 +806,20 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgPp4XZRnRHSMhGg0t
     fn serde_extensions() {
         let mut profile = Profile::new("tag:github.com,2023:veraison/ear");
         profile
-            .register_ear_extension("ext1", -1, ExtensionKind::String)
+            .register_ear_extension("ext1", -1, RawValueKind::String)
             .unwrap();
         profile
-            .register_ear_extension("ext2", -2, ExtensionKind::Integer)
+            .register_ear_extension("ext2", -2, RawValueKind::Integer)
             .unwrap();
         profile
-            .register_appraisal_extension("ext3", -1, ExtensionKind::Bytes)
+            .register_appraisal_extension("ext3", -1, RawValueKind::Bytes)
             .unwrap();
         register_profile(&profile).unwrap();
 
         let ear = serde_json::from_str::<Ear>(EAR_WITH_EXTENSIONS_STRING).unwrap();
 
         let v1 = ear.extensions.get_by_name("ext1").unwrap();
-        assert_eq!(v1, ExtensionValue::String("foo".to_string()));
+        assert_eq!(v1, RawValue::String("foo".to_string()));
 
         let text = serde_json::to_string(&ear).unwrap();
         assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,4 +38,7 @@ pub enum Error {
     // error while registering or accessing profiles
     #[error("profile error: {0}")]
     ProfileError(String),
+    // error during value conversion
+    #[error("value error: {0}")]
+    ValueError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //! [`Appraisal`]s. An extension is an additional field definition. Extensions can be defined by
 //! registering them with the `extensions` field of the corresponding struct. When registering an
 //! extension, you must provide a string name (used in JSON), an integer key (used in CBOR), and an
-//! [`ExtensionKind`] indicating which [`ExtensionValue`]s are valid.
+//! [`RawValueKind`] indicating which [`RawValue`]s are valid.
 //!
 //! ## Registering individual extensions
 //!
@@ -83,36 +83,36 @@
 //! they have been registered, their values can be set and queried
 //!
 //! ```
-//! use ear::{Ear, Appraisal, ExtensionKind, ExtensionValue};
+//! use ear::{Ear, Appraisal, RawValueKind, RawValue};
 //!
 //! let mut ear = Ear::new();
-//! ear.extensions.register("ext.company-name", -65537, ExtensionKind::String).unwrap();
+//! ear.extensions.register("ext.company-name", -65537, RawValueKind::String).unwrap();
 //!
 //! let mut appraisal = Appraisal::new();
 //! // extensions for Ear's and Appraisal's have their own namespaces, so it is
 //! // to use the same key in both.
-//! appraisal.extensions.register("ext.timestamp", -65537, ExtensionKind::Integer).unwrap();
+//! appraisal.extensions.register("ext.timestamp", -65537, RawValueKind::Integer).unwrap();
 //!
 //! ear.extensions.set_by_name(
 //!     "ext.company-name",
-//!     ExtensionValue::String("Acme Inc.".to_string()),
+//!     RawValue::String("Acme Inc.".to_string()),
 //! ).unwrap();
 //!
 //! appraisal.extensions.set_by_key(
 //!     -65537,
-//!     ExtensionValue::Integer(1723534859),
+//!     RawValue::Integer(1723534859),
 //! ).unwrap();
 //!
 //! ear.submods.insert("road-runner-trap".to_string(), appraisal);
 //!
 //! assert_eq!(
 //!    ear.extensions.get_by_key(&-65537).unwrap(),
-//!    ExtensionValue::String("Acme Inc.".to_string()),
+//!    RawValue::String("Acme Inc.".to_string()),
 //! );
 //!
 //! assert_eq!(
 //!    ear.submods["road-runner-trap"].extensions.get_by_name("ext.timestamp").unwrap(),
-//!    ExtensionValue::Integer(1723534859),
+//!    RawValue::Integer(1723534859),
 //! );
 //! ```
 //!
@@ -126,15 +126,15 @@
 //! registered, and can then be retrieved by its `id` when creating a new [`Ear`] or [`Appraisal`]
 //!
 //! ```
-//! use ear::{Ear, Appraisal, ExtensionKind, ExtensionValue, Profile, register_profile};
+//! use ear::{Ear, Appraisal, RawValueKind, RawValue, Profile, register_profile};
 //!
 //! fn init_profile() {
 //!     let mut profile = Profile::new("tag:github.com,2023:veraison/ear#acme-profile");
 //!
 //!     profile.register_ear_extension(
-//!         "ext.company-name", -65537, ExtensionKind::String).unwrap();
+//!         "ext.company-name", -65537, RawValueKind::String).unwrap();
 //!     profile.register_appraisal_extension(
-//!         "ext.timestamp", -65537, ExtensionKind::Integer).unwrap();
+//!         "ext.timestamp", -65537, RawValueKind::Integer).unwrap();
 //!
 //!     register_profile(&profile);
 //! }
@@ -150,25 +150,25 @@
 //!
 //!     ear.extensions.set_by_name(
 //!         "ext.company-name",
-//!         ExtensionValue::String("Acme Inc.".to_string()),
+//!         RawValue::String("Acme Inc.".to_string()),
 //!     ).unwrap();
 //!
 //!     appraisal.extensions.set_by_key(
 //!         -65537,
-//!         ExtensionValue::Integer(1723534859),
+//!         RawValue::Integer(1723534859),
 //!     ).unwrap();
 //!
 //!     ear.submods.insert("road-runner-trap".to_string(), appraisal);
 //!
 //!     assert_eq!(
 //!        ear.extensions.get_by_key(&-65537).unwrap(),
-//!        ExtensionValue::String("Acme Inc.".to_string()),
+//!        RawValue::String("Acme Inc.".to_string()),
 //!     );
 //!
 //!     assert_eq!(
 //!        ear.submods["road-runner-trap"]
 //!             .extensions.get_by_name("ext.timestamp").unwrap(),
-//!        ExtensionValue::Integer(1723534859),
+//!        RawValue::Integer(1723534859),
 //!     );
 //! }
 //!
@@ -188,7 +188,7 @@
 //! inside an EAR.
 //!
 //! ```
-//! use ear::{Ear, Algorithm, Appraisal, ExtensionKind, ExtensionValue};
+//! use ear::{Ear, Algorithm, Appraisal, RawValueKind, RawValue};
 //! use std::time::{SystemTime, Duration, UNIX_EPOCH};
 //!
 //! const VERIF_KEY: &str = r#"
@@ -212,13 +212,13 @@
 //! ear.vid.build = "vsts 0.0.1".to_string();
 //! ear.vid.developer = "https://veraison-project.org".to_string();
 //! ear.submods.insert("road-runner-trap".to_string(), Appraisal::new());
-//! ear.extensions.register("exp", 4, ExtensionKind::Integer).unwrap();
+//! ear.extensions.register("exp", 4, RawValueKind::Integer).unwrap();
 //!
 //! // expire 10 days from now
 //! let exp = SystemTime::now().checked_add(Duration::from_secs(60*60*24*10)).unwrap()
 //!                         .duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
 //!
-//! ear.extensions.set_by_name("exp", ExtensionValue::Integer(exp)).unwrap();
+//! ear.extensions.set_by_name("exp", RawValue::Integer(exp)).unwrap();
 //!
 //!
 //! let signed = ear
@@ -228,11 +228,11 @@
 //! let mut ear2 =
 //!     Ear::from_jwt_jwk(signed.as_str(), Algorithm::ES256, VERIF_KEY.as_bytes()).unwrap();
 //!
-//! ear2.extensions.register("exp", 4, ExtensionKind::Integer).unwrap();
+//! ear2.extensions.register("exp", 4, RawValueKind::Integer).unwrap();
 //!
 //! // Verify the token has not expired.
 //! let exp2 = match ear2.extensions.get_by_name("exp").unwrap() {
-//!     ExtensionValue::Integer(v) => Duration::from_secs(v as u64),
+//!     RawValue::Integer(v) => Duration::from_secs(v as u64),
 //!     _ => panic!(),
 //! };
 //! assert!(SystemTime::now().duration_since(UNIX_EPOCH).unwrap() < exp2);
@@ -322,14 +322,13 @@ pub use self::ear::Ear;
 pub use self::error::Error;
 pub use self::extension::get_profile;
 pub use self::extension::register_profile;
-pub use self::extension::ExtensionKind;
-pub use self::extension::ExtensionValue;
 pub use self::extension::Extensions;
 pub use self::extension::Profile;
 pub use self::id::VerifierID;
 pub use self::key::KeyAttestation;
 pub use self::nonce::Nonce;
 pub use self::raw::RawValue;
+pub use self::raw::RawValueKind;
 pub use self::trust::claim::TrustClaim;
 pub use self::trust::tier::TrustTier;
 pub use self::trust::vector::TrustVector;

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -123,7 +123,7 @@ impl<'de> Deserialize<'de> for OneNonce {
 
 struct OneNonceVisitor;
 
-impl<'de> Visitor<'de> for OneNonceVisitor {
+impl Visitor<'_> for OneNonceVisitor {
     type Value = OneNonce;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/trust/tier.rs
+++ b/src/trust/tier.rs
@@ -53,7 +53,7 @@ impl<'de> Deserialize<'de> for TrustTier {
 
 struct TrustTierVisitor;
 
-impl<'de> Visitor<'de> for TrustTierVisitor {
+impl Visitor<'_> for TrustTierVisitor {
     type Value = TrustTier;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Both these enums have similar definitions and serve similar purposes. To minimize duplication, remove ExtensionValue and replace it with RawValue inside Extensions implementation. Additional functionality of ExtensionValue is added to RawValue, and ExtensionKind is renamed to RawValueKind.

This also resolves issues with serialization of extensions, as ExtensionValue serialzation for maps and sequences was not implemented correctly, unlike in RawValue.

This addresses https://github.com/veraison/rust-ear/issues/32