### PR TITLE
Usability improvements and `clippy`/`fmt` fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Formatting checks
       run: cargo fmt --all -- --check
     - name: Clippy checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ear"
 description = "EAT Attestation Results implementation"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/veraison/rust-ear"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ openssl = "0.10.54"
 phf = {version = "0.11.1", features = ["macros", "serde"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0.93", features = ["raw_value"]}
-thiserror = "1.0.40"
+thiserror = "2.0.16"

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -17,7 +17,7 @@ pub fn decode_str(v: &str) -> Result<Vec<u8>, Error> {
 
 /// a `Vec<u8>` encoded as base64 in human readable serialization
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub struct Bytes(Vec<u8>);
+pub struct Bytes(pub Vec<u8>);
 
 impl Bytes {
     pub fn new() -> Self {

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -100,3 +100,24 @@ impl Visitor<'_> for BytesVisitor {
         Ok(Bytes::from(v))
     }
 }
+
+impl ToString for Bytes {
+    fn to_string(&self) -> String {
+        self.0
+            .iter()
+            .map(|v| format!("{:02x}", v))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn to_string() {
+        let bytes = Bytes(vec![222u8, 173u8, 190u8, 239u8]);
+        assert_eq!(bytes.to_string(), "deadbeef".to_string());
+    }
+}

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::Display;
+
 use base64::{self, engine::general_purpose, Engine as _};
 use serde::{
     de::{self, Deserialize, Visitor},
@@ -101,13 +103,14 @@ impl Visitor<'_> for BytesVisitor {
     }
 }
 
-impl ToString for Bytes {
-    fn to_string(&self) -> String {
+impl Display for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0
             .iter()
             .map(|v| format!("{:02x}", v))
             .collect::<Vec<_>>()
             .join("")
+            .fmt(f)
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -5,6 +5,9 @@
 // - tags are stripped when serializing to JSON
 // - byte strings are written as base64-encoded strings to JSON (meaning they deserialize as
 //   text strings, losing their original type).
+
+use std::fmt::Display;
+
 use serde::de::{self, Deserialize, EnumAccess, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, Serializer};
 use serde::ser::{SerializeMap as _, SerializeSeq as _, SerializeTupleVariant as _};
@@ -251,8 +254,8 @@ impl<'de> Visitor<'de> for RawValueVisitor {
     }
 }
 
-impl ToString for RawValue {
-    fn to_string(&self) -> String {
+impl Display for RawValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Null => "Null".to_string(),
             Self::Integer(v) => v.to_string(),
@@ -260,18 +263,23 @@ impl ToString for RawValue {
             Self::Bool(v) => v.to_string(),
             Self::Bytes(b) => b.to_string(),
             Self::String(s) => format!(r#""{}""#, s),
-            Self::Array(vs) => format!(r#"[{}]"#, vs
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")),
-            Self::Map(vs) => format!(r#"{{{}}}"#, vs
-                .iter()
-                .map(|(k, v)| format!("{0}: {1}", k.to_string(), v.to_string()))
-                .collect::<Vec<_>>()
-                .join(", ")),
-            Self::Tagged(t, v) => format!("#6.{0}({1})", t, v.to_string()),
+            Self::Array(vs) => format!(
+                r#"[{}]"#,
+                vs.iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::Map(vs) => format!(
+                r#"{{{}}}"#,
+                vs.iter()
+                    .map(|(k, v)| format!("{0}: {1}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::Tagged(t, v) => format!("#6.{0}({1})", t, v),
         }
+        .fmt(f)
     }
 }
 

--- a/src/trust/claim.rs
+++ b/src/trust/claim.rs
@@ -465,9 +465,14 @@ impl TrustClaim {
 }
 
 impl std::fmt::Debug for TrustClaim {
-
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"TrustClaim{{"{0}({1})": {2}}}"#, self.tag(), self.key(), self.value())
+        write!(
+            f,
+            r#"TrustClaim{{"{0}({1})": {2}}}"#,
+            self.tag(),
+            self.key(),
+            self.value()
+        )
     }
 }
 

--- a/src/trust/claim.rs
+++ b/src/trust/claim.rs
@@ -340,7 +340,7 @@ pub static SOURCED_DATA_CLAIM_MAP: &Map<i8, ValueDescription<'static>> = &phf_ma
 /// This is a claim regarding the trustworthiness of one aspect of the attested environment, as
 /// defined in
 /// <https://datatracker.ietf.org/doc/html/draft-ietf-rats-ar4si-04#name-trustworthiness-claims>
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct TrustClaim {
     /// Claim value
     pub value: Option<i8>,
@@ -461,6 +461,13 @@ impl TrustClaim {
             return COMMON_CLAIM_MAP.get(&val);
         }
         self.value_desc.get(&val)
+    }
+}
+
+impl std::fmt::Debug for TrustClaim {
+
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, r#"TrustClaim{{"{0}({1})": {2}}}"#, self.tag(), self.key(), self.value())
     }
 }
 

--- a/src/trust/tier.rs
+++ b/src/trust/tier.rs
@@ -56,9 +56,9 @@ impl Visitor<'_> for TrustTierVisitor {
     where
         E: de::Error,
     {
-        return Ok(value
+        value
             .try_into()
-            .map_err(|_| E::custom(format!("Unexpected TrustTier value: {value}")))?);
+            .map_err(|_| E::custom(format!("Unexpected TrustTier value: {value}")))
     }
 
     fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E>
@@ -105,9 +105,9 @@ impl Visitor<'_> for TrustTierVisitor {
     where
         E: de::Error,
     {
-        return Ok(value
+        value
             .try_into()
-            .map_err(|_| E::custom(format!("Unexpected TrustTier value: {value}")))?);
+            .map_err(|_| E::custom(format!("Unexpected TrustTier value: {value}")))
     }
 }
 


### PR DESCRIPTION
- Add conversions to/from basic types for `TrustTier`
- Expose `Byte`'s inner values to allow for literal instatiations
- Add human-readable representations for `Bytes` and `RawValue`
- Custom `Debug` implementation for `TrustClaim` that is more readable than the derived one
- `clippy` and `fmt` fixes.