### PR TITLE
feat: add missing string conversions

### DIFF
--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -56,6 +56,20 @@ impl TryFrom<&str> for OneNonce {
     }
 }
 
+impl TryFrom<String> for OneNonce {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self, Error> {
+        if v.len() >= 8 && v.len() <= 88 {
+            Ok(OneNonce::String(v))
+        } else {
+            Err(Error::ParseError(
+                "nonce must be between 8 and 88 characters".to_string(),
+            ))
+        }
+    }
+}
+
 impl fmt::Display for OneNonce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let enc: String;
@@ -171,6 +185,14 @@ impl TryFrom<&str> for Nonce {
     }
 }
 
+impl TryFrom<String> for Nonce {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self, Error> {
+        Ok(Nonce(vec![OneNonce::try_from(v)?]))
+    }
+}
+
 impl TryFrom<&[&str]> for Nonce {
     type Error = Error;
 
@@ -178,6 +200,24 @@ impl TryFrom<&[&str]> for Nonce {
         let mut res: Nonce = Nonce(vec![]);
         for (i, v) in vals.iter().enumerate() {
             res.0.push(OneNonce::try_from(*v).map_err(|e| {
+                let msg = match e {
+                    Error::ParseError(s) => s,
+                    _ => e.to_string(),
+                };
+                Error::ParseError(format!("item {i}: {msg}"))
+            })?);
+        }
+        Ok(res)
+    }
+}
+
+impl TryFrom<&[String]> for Nonce {
+    type Error = Error;
+
+    fn try_from(vals: &[String]) -> Result<Self, Error> {
+        let mut res: Nonce = Nonce(vec![]);
+        for (i, v) in vals.iter().enumerate() {
+            res.0.push(OneNonce::try_from(v.as_str()).map_err(|e| {
                 let msg = match e {
                     Error::ParseError(s) => s,
                     _ => e.to_string(),

--- a/src/trust/claim.rs
+++ b/src/trust/claim.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 // SPDX-License-Identifier: Apache-2.0
 use crate::error::Error;
 
@@ -455,6 +457,7 @@ impl TrustClaim {
         }
     }
 
+    /// Return the `ValueDescription` for the current value of this claim.
     fn value_desc(&self) -> Option<&ValueDescription> {
         let val = self.value();
         if (-1..=1).contains(&val) || val == 99 {
@@ -473,6 +476,12 @@ impl std::fmt::Debug for TrustClaim {
             self.key(),
             self.value()
         )
+    }
+}
+
+impl Display for TrustClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value_name().fmt(f)
     }
 }
 
@@ -550,6 +559,12 @@ impl TryFrom<i8> for TrustClaim {
 
 impl From<TrustClaim> for String {
     fn from(val: TrustClaim) -> String {
+        val.tag().to_string()
+    }
+}
+
+impl From<&TrustClaim> for String {
+    fn from(val: &TrustClaim) -> String {
         val.tag().to_string()
     }
 }

--- a/src/trust/tier.rs
+++ b/src/trust/tier.rs
@@ -7,7 +7,7 @@ use serde::{
     ser::{Serialize, Serializer},
     Deserialize,
 };
-use std::fmt;
+use std::fmt::{self, Display};
 
 /// Tier of a trustworthiness claim's value
 ///
@@ -19,6 +19,12 @@ pub enum TrustTier {
     Affirming,
     Warning,
     Contraindicated,
+}
+
+impl TrustTier {
+    pub fn as_str(&self) -> &str {
+        self.into()
+    }
 }
 
 impl Serialize for TrustTier {
@@ -111,6 +117,12 @@ impl Visitor<'_> for TrustTierVisitor {
     }
 }
 
+impl Display for TrustTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 impl TryFrom<&str> for TrustTier {
     type Error = Error;
 
@@ -141,6 +153,17 @@ impl TryFrom<i8> for TrustTier {
 
 impl From<TrustTier> for String {
     fn from(val: TrustTier) -> String {
+        match val {
+            TrustTier::None => "none".to_string(),
+            TrustTier::Affirming => "affirming".to_string(),
+            TrustTier::Warning => "warning".to_string(),
+            TrustTier::Contraindicated => "contraindicated".to_string(),
+        }
+    }
+}
+
+impl From<&TrustTier> for String {
+    fn from(val: &TrustTier) -> String {
         match val {
             TrustTier::None => "none".to_string(),
             TrustTier::Affirming => "affirming".to_string(),


### PR DESCRIPTION
- Add TryFrom<String> implementations for Nonce. Previously only had TryFrom<&str>, which necessitated creation of temporary variables when dealing with returned owned strings.
- Add to/from String conversions for TrustTier and TrustClaim.